### PR TITLE
Fix cross compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ URL = https://github.com/wirbel-at-vdr-portal/librepfunc
 #/******************************************************************************
 # * if you prefer verbose non-coloured build messages, remove the '@' here:
 # *****************************************************************************/
-CXX = @g++
+CXX ?= @g++
 CXXFLAGS += -g -O3 -fPIC -Wall -Wextra -Werror=overloaded-virtual -Wfatal-errors
 CXXFLAGS += -DVERSION=\"$(VERSION)\"
 DEFINES   = -D_POSIX_C_SOURCE
@@ -61,7 +61,7 @@ GN=\e[1;32m
 #/******************************************************************************
 # * programs, override if on different paths.
 # *****************************************************************************/
-AR               = @ar
+AR              ?= @ar
 CD              ?= cd
 CP              ?= cp
 CHMOD           ?= chmod


### PR DESCRIPTION
For cross compiles both AR and CXX need to be override, don’t use the default ar and g++ compiler.

Tested by cross compiling both arm and aarch64 on and x86_64 buildhost